### PR TITLE
feat: database configuration

### DIFF
--- a/packages/server/src/config/databaseConfig.ts
+++ b/packages/server/src/config/databaseConfig.ts
@@ -1,15 +1,25 @@
-import pkg from "pg";
 import dotenv from "dotenv";
+import path from "path";
+import pkg from "pg";
 import PoolConfigInterface from "./interfaces/databaseConfigInterface.js";
-dotenv.config();
+
+const envPath = process.env.NODE_ENV === "development" ? path.resolve(process.cwd(), ".env.development") : path.resolve(process.cwd(), ".env");
+
+console.log(`[databaseConfig] Loading environment variables from: ${envPath}`);
+const dotenvResult = dotenv.config({ path: envPath });
+
+if (dotenvResult.error) {
+   console.error(`[databaseConfig] Error loading .env file from ${envPath}:`, dotenvResult.error);
+   throw new Error(`Failed to load environment variables from ${envPath}`);
+}
 
 const { Pool } = pkg;
 
 const poolConfig: PoolConfigInterface = {
-   host: process.env.DB_HOST as string,
-   user: process.env.DB_USER as string,
-   password: process.env.DB_PASSWORD as string,
-   database: process.env.DB_NAME as string,
+   host: process.env.DB_HOST,
+   user: process.env.DB_USER,
+   password: process.env.DB_PASSWORD,
+   database: process.env.DB_NAME,
    port: process.env.DB_PORT ? parseInt(process.env.DB_PORT, 10) : 5432,
    max: process.env.DB_MAX ? parseInt(process.env.DB_MAX, 10) : 10,
    idleTimeoutMillis: process.env.DB_IDLE_TIMEOUT ? parseInt(process.env.DB_IDLE_TIMEOUT, 10) : 30000,

--- a/packages/server/src/config/interfaces/databaseConfigInterface.ts
+++ b/packages/server/src/config/interfaces/databaseConfigInterface.ts
@@ -1,12 +1,12 @@
 interface PoolConfigInterface {
-   host: string;
-   user: string;
-   password: string;
-   database: string;
+   host?: string;
+   user?: string;
+   password?: string;
+   database?: string;
    port?: number;
    max?: number;
    idleTimeoutMillis?: number;
-   ssl?: any;
+   ssl?: boolean | { rejectUnauthorized: boolean };
 }
 
 export default PoolConfigInterface;


### PR DESCRIPTION
## Pull Request Title "[feat] database configuration"

---

## Description

- What changes were made?

On the database config file a envPath varaible was introduced to decide which path the database should resolve depending on the environment being development or not. Lastly, the poolConfig properties which were using "as string" now accept those directly on their interface.

- Are there any notable technical details or implementation choices?

The goal was to load different configuration files depending on wether the database was used on a development environment or not, maintaining different configurations completly separated.

The removal of the "as string" arguments was a better approach to handle the possibility of undefined values from the environment variables. Instead of converting those (like NaN for example) to strings creating issues, this is a better option. 

## How Has This Been Tested?

- [X] Manual testing

---
