### PR TITLE
fix: correct success status in error response for getAllProjects

### DIFF
--- a/packages/server/src/controllers/projectController/projectController.ts
+++ b/packages/server/src/controllers/projectController/projectController.ts
@@ -43,7 +43,7 @@ export const getAllProjects = async (_: any, res: any) => {
    } catch (error) {
       console.error("Error fetching projects:", error);
       res.status(500).json({
-         success: true,
+         success: false,
          message: "Internal server error",
       });
    }


### PR DESCRIPTION
## Pull Request Title "[fix] corrected success status in error response for getAllProjects"

---

## Description

- What problem does this PR solve?

Before, any error that was catch will return a status of 500 with a success true instead of false.

## How Has This Been Tested?

- [X] Manual testing
- [ ] Added new tests
- [ ] Existing tests passed

---
