### PR TITLE
fix: update API_BASE_URL to use VITE_API_BASE_URL environment variable

### DIFF
--- a/packages/client/src/utils/hooks/useFetchData/data/useFetchDataData.ts
+++ b/packages/client/src/utils/hooks/useFetchData/data/useFetchDataData.ts
@@ -4,4 +4,4 @@ export interface FetchResult<T> {
    error: Error | null;
 }
 
-export const API_BASE_URL = import.meta.env.HOST;
+export const API_BASE_URL = import.meta.env.VITE_API_BASE_URL;


### PR DESCRIPTION
## fix: update API_BASE_URL to use VITE_API_BASE_URL environment variable

---

## Description

- What problem does this PR solve?

Vite only will expose environment variables to the client side if they are prefixed with the "VITE_".

## How Has This Been Tested?

- [X] Manual testing

---
