### PR TITLE
feat: theme provider retro mode addition

### DIFF
--- a/packages/client/src/utils/themeContext/data/themeContextData.ts
+++ b/packages/client/src/utils/themeContext/data/themeContextData.ts
@@ -1,4 +1,4 @@
-export type ThemeMode = "light" | "dark";
+export type ThemeMode = "light" | "dark" | "retro";
 
 export interface ThemeContextType {
    mode: ThemeMode;

--- a/packages/client/src/utils/themeProvider/themeProvider.tsx
+++ b/packages/client/src/utils/themeProvider/themeProvider.tsx
@@ -1,17 +1,17 @@
-import { useState, useEffect, ReactNode } from "react";
-import { ThemeMode, ThemeContextType } from "../themeContext/data/themeContextData";
+import { ReactNode, useEffect, useState } from "react";
+import { ThemeContextType, ThemeMode } from "../themeContext/data/themeContextData";
 import { themeContext } from "../themeContext/themeContext";
 
 export const ThemeProvider = ({ children }: { children: ReactNode }) => {
    const [mode, setMode] = useState<ThemeMode>(() => {
       if (typeof window === "undefined") return "light";
 
+      const savedMode = localStorage.getItem("themeMode") as ThemeMode;
+      if (savedMode === "light" || savedMode === "dark" || savedMode === "retro") return savedMode;
+
       if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
          return "dark";
       }
-
-      const savedMode = localStorage.getItem("themeMode") as ThemeMode;
-      if (savedMode === "light" || savedMode === "dark") return savedMode;
 
       return "light";
    });
@@ -26,6 +26,20 @@ export const ThemeProvider = ({ children }: { children: ReactNode }) => {
    const toggleMode = () => {
       setMode((prevMode) => (prevMode === "light" ? "dark" : "light"));
    };
+
+   /* Toggle mode function with retro mode in it.
+   const toggleMode = () => {
+      setMode((prevMode) => {
+         if (prevMode === "light") {
+            return "dark";
+         } else if (prevMode === "dark") {
+            return "retro";
+         } else { 
+            return "light";
+         }
+      });
+   };
+   */
 
    const contextValue: ThemeContextType = {
       mode,


### PR DESCRIPTION
## feat: theme provider retro mode addition

---

## Description

A retro mode was added to the theme provider and its utils file. A soon to be implemented function will allow users to switch between light, dark and retro modes.

## How Has This Been Tested?

- [X] Manual testing
- [ ] Added new tests
- [ ] Existing tests passed

---
