### PR TITLE
fix: remove unnecessary prop from HeaderNavigation component

### DIFF
--- a/packages/client/src/components/header/Header.tsx
+++ b/packages/client/src/components/header/Header.tsx
@@ -22,7 +22,7 @@ const Header = () => {
          `}
       >
          <HeaderLogo />
-         <HeaderNavigation headerIsVisible={isVisible} />
+         <HeaderNavigation />
          <HeaderModeSwitcher />
       </header>
    );


### PR DESCRIPTION
## fix: remove unnecessary prop from HeaderNavigation component

---

## Description

Removed unnecesary props as now HeaderNavigation component will not make use of them directly.

## How Has This Been Tested?

- [X] Existing tests passed

---
