### PR TITLE
fix: update transition duration in useCommonHoverAnimations and correct ProjectInterface import path

### DIFF
--- a/packages/client/src/utils/hooks/useCommonHoverAnimations/useCommonHoverAnimations.tsx
+++ b/packages/client/src/utils/hooks/useCommonHoverAnimations/useCommonHoverAnimations.tsx
@@ -11,7 +11,7 @@ export interface UseCommonHoverAnimationsReturn {
 export const useCommonHoverAnimations = (): UseCommonHoverAnimationsReturn => {
    const whileHover = { scale: 1.05 };
    const whileTap = { scale: 0.85 };
-   const transition: Transition = { duration: 0.2, ease: "easeOut" as const };
+   const transition: Transition = { duration: 0.3, ease: "easeOut" as const };
 
    return {
       whileHover,

--- a/packages/client/src/utils/hooks/useHeaderProjectsCommandProcessor/data/useHeaderProjectsCommandProcessorData.ts
+++ b/packages/client/src/utils/hooks/useHeaderProjectsCommandProcessor/data/useHeaderProjectsCommandProcessorData.ts
@@ -1,4 +1,4 @@
-import type { ProjectInterface } from "../../../../features/project/data/projectData";
+import type { ProjectInterface } from "../../../../types/projectInterface";
 
 export interface UseHeaderProjectsCommandProcessorProps {
    projects: ProjectInterface[] | null | undefined;


### PR DESCRIPTION
## fix: update transition duration in useCommonHoverAnimations and correct ProjectInterface import path


---

## Description

PR self-describes what's going on on this PR.

## How Has This Been Tested?

- [x] Manual testing
- [ ] Added new tests
- [ ] Existing tests passed
