### PR TITLE
refactor: update project routing and API to use project_slug instead of project_name

### DIFF
--- a/packages/client/src/app/App.tsx
+++ b/packages/client/src/app/App.tsx
@@ -39,7 +39,7 @@ function AppContent() {
                }
             />
             <Route
-               path="/projects/:projectName"
+               path="/projects/:projectSlug"
                element={
                   <ErrorBoundary fallback={<GenericErrorPage />}>
                      <Project />

--- a/packages/client/src/components/header/components/header-navigation/components/header-navigation-retro/HeaderNavigationRetro.tsx
+++ b/packages/client/src/components/header/components/header-navigation/components/header-navigation-retro/HeaderNavigationRetro.tsx
@@ -49,7 +49,7 @@ const HeaderNavigationRetro = (): React.ReactElement => {
                <ul aria-label="projects-menu-button" className={`header__navigation-retro-list absolute origin-top top-[27px] left-[-50px] w-[600px] grid grid-cols-3 grid-rows-2 ${theme === "light" ? "bg-[#B6CCFE]" : "bg-[#E2EAFC]"} visible ${projectsAreClosing ? "header__navigation-retro-list--closing" : ""}`}>
                   {projects.map((project) => (
                      <li key={project.project_id} className={`header__navigation-retro-list-item p-2.5 hover:${theme === "light" ? "bg-[#ABC4FF]" : "bg-[#EDF2FB]"} cursor-pointer`}>
-                        <Link to={`/projects/${project.project_name}`} className={`header__navigation-retro-list-link block w-full font-mono ${theme === "light" ? "text-[#E2EAFC]" : "text-[#B6CCFE]"}`}>
+                        <Link to={`/projects/${project.project_slug}`} className={`header__navigation-retro-list-link block w-full font-mono ${theme === "light" ? "text-[#E2EAFC]" : "text-[#B6CCFE]"}`}>
                            <span className="header__navigation-retro-list-link-text block w-full">{formatName(project.project_name)}</span>
                         </Link>
                      </li>

--- a/packages/client/src/features/project/Project.tsx
+++ b/packages/client/src/features/project/Project.tsx
@@ -13,8 +13,8 @@ import { PROJECT_ARIA_LABEL, PROJECT_ERROR_ARIA_LABEL, PROJECT_LOADING_ARIA_LABE
 import { buildProjectApiPath } from "./utils/buildProjectApiPath";
 
 const Project = (): React.ReactElement => {
-   const { projectName } = useParams<{ projectName: string }>();
-   const apiPath = buildProjectApiPath(projectName);
+   const { projectSlug } = useParams<{ projectSlug: string }>();
+   const apiPath = buildProjectApiPath(projectSlug);
    const { data: project, loading, error } = useFetchData<ProjectInterface>(apiPath);
    const isDesktop = useMediaQuery("(min-width: 1024px)");
 

--- a/packages/client/src/features/project/components/project-related/components/project-related-container-compact/components/project-related-container-projects/components/project-related-container-projects-project/ProjectRelatedContainerProjectsProject.tsx
+++ b/packages/client/src/features/project/components/project-related/components/project-related-container-compact/components/project-related-container-projects/components/project-related-container-projects-project/ProjectRelatedContainerProjectsProject.tsx
@@ -25,7 +25,7 @@ const ProjectRelatedContainerProjectsProject = ({ firstPart, secondPart, project
 
    return (
       <motion.li ref={containerRef} style={{ y, backgroundColor }} className="project__related-container-projects-project" data-testid="related-project">
-         <Link key={project.project_id} to={`/projects/${project.project_name}`} className="project__related-container-projects-project-link">
+         <Link key={project.project_id} to={`/projects/${project.project_slug}`} className="project__related-container-projects-project-link">
             <div className="project__related-container-projects-project-content flex flex-col relative h-fit overflow-hidden">
                <div className="project__related-container-projects-project-upper-part">
                   <img className="project__related-container-projects-project-image min-w-[272px] md:max-w-[320px] md:max-h-[320px]" src={projectSecondaryLogo} alt={PROJECT_RELATED_CONTAINER_PROJECTS_IMAGE_ALT_TEXT} />

--- a/packages/client/src/features/project/components/project-related/components/project-related-container-desktop/components/project-related-container-projects/components/project-related-container-projects-project/ProjectRelatedContainerProjectsProject.tsx
+++ b/packages/client/src/features/project/components/project-related/components/project-related-container-desktop/components/project-related-container-projects/components/project-related-container-projects-project/ProjectRelatedContainerProjectsProject.tsx
@@ -28,7 +28,7 @@ const ProjectRelatedContainerProjectsProject = ({ firstPart, secondPart, project
 
    return (
       <motion.li ref={containerRef} onHoverStart={() => setIsHovered(true)} onHoverEnd={() => setIsHovered(false)} style={{ y, backgroundColor }} className="project__related-container-projects-project" data-testid="related-project">
-         <Link key={project.project_id} to={`/projects/${project.project_name}`} className="project__related-container-projects-project-link">
+         <Link key={project.project_id} to={`/projects/${project.project_slug}`} className="project__related-container-projects-project-link">
             <div className="project__related-container-projects-project-content flex flex-col relative h-fit overflow-hidden">
                <div className="project__related-container-projects-project-upper-part">
                   <img className="project__related-container-projects-project-image size-[clamp(1px,34.2vw,550px)]" src={projectSecondaryLogo} alt={PROJECT_RELATED_CONTAINER_PROJECTS_IMAGE_ALT_TEXT} />

--- a/packages/client/src/features/project/utils/buildProjectApiPath.ts
+++ b/packages/client/src/features/project/utils/buildProjectApiPath.ts
@@ -1,3 +1,3 @@
-export const buildProjectApiPath = (projectName: string | undefined): string | null => {
-   return projectName ? `projects/${projectName}` : null;
+export const buildProjectApiPath = (projectSlug: string | undefined): string | null => {
+   return projectSlug ? `projects/${projectSlug}` : null;
 };

--- a/packages/client/src/features/projects-list-detailed/components/projects-list-detailed-project-compact/ProjectsListDetailedProjectCompact.tsx
+++ b/packages/client/src/features/projects-list-detailed/components/projects-list-detailed-project-compact/ProjectsListDetailedProjectCompact.tsx
@@ -17,7 +17,7 @@ const ProjectsListDetailedProjectCompact = ({ project, isOddProject }: ProjectsL
 
    return (
       <motion.li initial={initial} whileInView={whileInView} transition={listTransition} viewport={viewport} className="projects-list-detailed__list-item projects-list-detailed__list-item--compact flex flex-col rounded-xs border-0 group bg-card p-6 transition duration-300 ease-in-out" aria-label={`Project list item: ${project.project_name}`}>
-         <Link className="projects-list-detailed__link contents" to={`/projects/${project.project_name}`} aria-label={`View ${project.project_name}`}>
+         <Link className="projects-list-detailed__link contents" to={`/projects/${project.project_slug}`} aria-label={`View ${project.project_name}`}>
             <div className="flex flex-col items-center gap-5">
                <div className="projects-list-detailed__second-wrapper flex shrink-0 size-40 items-center justify-center rounded-[50%] bg-card" aria-label={`Project ${project.project_name} logo`}>
                   <img src={projectPrimaryLogo} className="h-[50%] w-[70%] object-contain" alt={`${PROJECT_LOGO_ALT_TEXT} for ${project.project_name}`} />

--- a/packages/client/src/features/projects-list-detailed/components/projects-list-detailed-project-desktop/ProjectsListDetailedProjectDesktop.tsx
+++ b/packages/client/src/features/projects-list-detailed/components/projects-list-detailed-project-desktop/ProjectsListDetailedProjectDesktop.tsx
@@ -14,7 +14,7 @@ const ProjectsListDetailedProjectDesktop = ({ project, isOddProject }: ProjectsL
 
    return (
       <motion.li initial={{ x: isOddProject ? -700 : 700, opacity: 0 }} whileInView={{ x: 0, opacity: 1 }} transition={{ duration: 0.1, ease: "easeInOut" }} viewport={{ once: true, amount: 0.1 }} className="projects-list-detailed__list-item projects-list-detailed__list-item--desktop grid min-h-screen cursor-pointer rounded-xs border-0 group bg-card p-12 transition duration-300 ease-in-out hover:bg-accent" aria-label={`Project list item: ${project.project_name}`}>
-         <Link className="projects-list-detailed__link contents" to={`/projects/${project.project_name}`} aria-label={`View ${project.project_name}`}>
+         <Link className="projects-list-detailed__link contents" to={`/projects/${project.project_slug}`} aria-label={`View ${project.project_name}`}>
             <div className={`flex flex-row items-center justify-between py-12.5 ${isOddProject ? "" : "flex-row-reverse"}`}>
                <div className="projects-list-detailed__first-wrapper flex flex-col max-w-3/4 text-left" aria-label={`Project ${project.project_name} details`}>
                   <span className="text-[clamp(var(--font-size-heading-xl),5vw,var(--font-size-display))] font-bold transition-colors duration-300 text-heading leading-none group-hover:text-white">{firstPartName}</span>

--- a/packages/client/src/features/projects-list/components/projects-list-project-compact/ProjectsListProjectCompact.tsx
+++ b/packages/client/src/features/projects-list/components/projects-list-project-compact/ProjectsListProjectCompact.tsx
@@ -12,7 +12,7 @@ const ProjectsListProjectCompact = ({ project, index }: ProjectsListProjectProps
    return (
       <>
          <li className="projects-list__list-item flex flex-col justify-center items-center gap-5 p-5 border-0 rounded-xs transition duration-00 ease-in-out bg-card group" aria-label={`Project ${index} list item: ${project.project_name}`}>
-            <Link className="projects-list__link contents" to={`/projects/${project.project_name}`} aria-label={`View ${project.project_name}`}>
+            <Link className="projects-list__link contents" to={`/projects/${project.project_slug}`} aria-label={`View ${project.project_name}`}>
                {isTablet ? (
                   <div className="grid grid-cols-2">
                      <div className={`projects-list__list-item-content ${project.project_id % 2 ? "order-1" : "order-2"}`}>

--- a/packages/client/src/features/projects-list/components/projects-list-project-desktop/ProjectsListProjectDesktop.tsx
+++ b/packages/client/src/features/projects-list/components/projects-list-project-desktop/ProjectsListProjectDesktop.tsx
@@ -65,7 +65,7 @@ const ProjectsListProjectDesktop = ({ project, index }: ProjectsListProjectProps
    return (
       <>
          <li className="projects-list__list-item grid gap-24 p-12 cursor-pointer border-0 rounded-xs transition duration-300 ease-in-out bg-card hover:bg-accent group" aria-label={`Project ${index} list item: ${project.project_name}`} onMouseMove={handleMouseMove} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave}>
-            <Link className="projects-list__link contents" to={`/projects/${project.project_name}`} aria-label={`View ${project.project_name}`}>
+            <Link className="projects-list__link contents" to={`/projects/${project.project_slug}`} aria-label={`View ${project.project_name}`}>
                <div className="projects-list__list-item-content flex justify-center items-center gap-0">
                   {PROJECT_LETTERS.map((letter, letterIndex) =>
                      letterIndex === replacedIndex ? (

--- a/packages/client/src/types/projectInterface.ts
+++ b/packages/client/src/types/projectInterface.ts
@@ -28,4 +28,5 @@ export interface ProjectInterface {
    project_timeline_event_05_title: string;
    project_timeline_event_05: string;
    project_external_url: string | null;
+   project_slug: string;
 }

--- a/packages/client/src/utils/hooks/useHeaderProjectsCommandProcessor/useHeaderProjectsCommandProcessor.tsx
+++ b/packages/client/src/utils/hooks/useHeaderProjectsCommandProcessor/useHeaderProjectsCommandProcessor.tsx
@@ -28,7 +28,7 @@ export const useHeaderProjectsCommandProcessor = ({ projects, setProjectsAreVisi
                   if (matchingProject) {
                      setProjectsAreVisible(false);
                      setProjectsAreClosing(false);
-                     window.location.href = `/projects/${matchingProject.project_name}`;
+                     window.location.href = `/projects/${matchingProject.project_slug}`;
                   } else {
                      console.error(`Project "${projectName}" not found`);
                   }

--- a/packages/server/src/controllers/projectController/__tests__/projectController.test.ts
+++ b/packages/server/src/controllers/projectController/__tests__/projectController.test.ts
@@ -1,16 +1,15 @@
-import { getProjectByName } from "../projectController.js";
-import { dbQuery } from "../../../config/databaseConfig.js";
 import { Mock } from "vitest"; // TODO: Get rid of this import statement by using globals importing
-import { mockRequest, mockResponse, statusSpy, jsonSpy, initializeMocks, initializeConsoleErrorSpy, restoreConsoleErrorSpy, deinitializeMocks } from "./test-utils/test-utils.js";
+import { dbQuery } from "../../../config/databaseConfig.js";
+import { getProjectBySlug } from "../projectController.js";
+import { deinitializeMocks, initializeConsoleErrorSpy, initializeMocks, jsonSpy, mockRequest, mockResponse, restoreConsoleErrorSpy, statusSpy } from "./test-utils/testUtils.js";
+
+vi.mock("../../../config/databaseConfig.js");
 
 describe("projectController controller tests", () => {
-   beforeAll(() => {
-      vi.mock("../../../config/databaseConfig.js");
-   });
 
    beforeEach(() => {
       initializeConsoleErrorSpy();
-      initializeMocks("project 01");
+      initializeMocks("project-01");
    });
 
    afterEach(() => {
@@ -18,52 +17,52 @@ describe("projectController controller tests", () => {
       deinitializeMocks();
    });
 
-   test("should return a correct project given a valid name", async () => {
-      const mockProject = { project_name: "project 01" };
+   test("should return a correct project given a valid slug", async () => {
+      const mockProject = { project_slug: "project-01" };
 
       (dbQuery as Mock).mockResolvedValueOnce({ rows: [mockProject] });
 
-      await getProjectByName(mockRequest, mockResponse);
+      await getProjectBySlug(mockRequest, mockResponse);
 
       expect(jsonSpy).toHaveBeenCalledWith(mockProject);
    });
 
-   test("should return a correct project given a valid name with different case", async () => {
-      initializeMocks("ProJect 01");
+   test("should return a correct project given a valid slug with different case", async () => {
+      initializeMocks("ProJect-01");
 
-      const mockProject = { project_name: "project 01" };
+      const mockProject = { project_slug: "project-01" };
 
       (dbQuery as Mock).mockResolvedValueOnce({ rows: [mockProject] });
 
-      await getProjectByName(mockRequest, mockResponse);
+      await getProjectBySlug(mockRequest, mockResponse);
 
       expect(jsonSpy).toHaveBeenCalledWith(mockProject);
    });
 
-   test("should not return a project given an invalid name", async () => {
-      initializeMocks("invalid project");
+   test("should not return a project given an invalid slug", async () => {
+      initializeMocks("invalid-project");
 
       (dbQuery as Mock).mockResolvedValueOnce({ rows: [] });
 
-      await getProjectByName(mockRequest, mockResponse);
+      await getProjectBySlug(mockRequest, mockResponse);
 
       expect(statusSpy).toHaveBeenCalledWith(404);
-      expect(jsonSpy).toHaveBeenCalledWith({ message: `Project with name ${mockRequest.params.projectName} not found` });
+      expect(jsonSpy).toHaveBeenCalledWith({ message: `Project with slug ${mockRequest.params.projectSlug} not found` });
    });
 
-   test("should return a 400 status code if projectName parameter is missing", async () => {
+   test("should return a 400 status code if projectSlug parameter is missing", async () => {
       initializeMocks("");
 
-      await getProjectByName(mockRequest, mockResponse);
+      await getProjectBySlug(mockRequest, mockResponse);
 
       expect(statusSpy).toHaveBeenCalledWith(400);
-      expect(jsonSpy).toHaveBeenCalledWith({ message: "Project name is required" });
+      expect(jsonSpy).toHaveBeenCalledWith({ message: "Project slug is required" });
    });
 
    test("should return a 500 status code and an error message if an error occurs", async () => {
       (dbQuery as Mock).mockRejectedValueOnce(new Error("Database error"));
 
-      await getProjectByName(mockRequest, mockResponse);
+      await getProjectBySlug(mockRequest, mockResponse);
 
       expect(statusSpy).toHaveBeenCalledWith(500);
       expect(jsonSpy).toHaveBeenCalledWith({ message: "Internal server error" });

--- a/packages/server/src/controllers/projectController/__tests__/test-utils/testUtils.ts
+++ b/packages/server/src/controllers/projectController/__tests__/test-utils/testUtils.ts
@@ -4,8 +4,8 @@ let statusSpy: any;
 let jsonSpy: any;
 let consoleErrorSpy: any;
 
-const initializeMocks = (projectName: string) => {
-   mockRequest = { params: { projectName } };
+const initializeMocks = (projectSlug: string) => {
+   mockRequest = { params: { projectSlug } };
    mockResponse = { status: vi.fn().mockReturnThis(), json: vi.fn() };
    statusSpy = vi.spyOn(mockResponse, "status");
    jsonSpy = vi.spyOn(mockResponse, "json");

--- a/packages/server/src/controllers/projectController/projectController.ts
+++ b/packages/server/src/controllers/projectController/projectController.ts
@@ -1,22 +1,22 @@
 import { dbQuery } from "../../config/databaseConfig.js";
 
-export const getProjectByName = async (req: any, res: any) => {
-   const projectName = req.params.projectName;
+export const getProjectBySlug = async (req: any, res: any) => {
+   const projectSlug = req.params.projectSlug;
 
-   if (!projectName) {
+   if (!projectSlug) {
       return res.status(400).json({
          success: false,
-         message: "Project name is required",
+         message: "Project slug is required",
       });
    }
 
    try {
-      const result = await dbQuery("SELECT * FROM projects WHERE LOWER(project_name) = $1", [projectName.toLowerCase()]);
+      const result = await dbQuery("SELECT * FROM projects WHERE project_slug = $1", [projectSlug.toLowerCase()]);
 
       if (result.rows.length === 0) {
          return res.status(404).json({
             success: false,
-            message: `Project with name ${projectName} not found`,
+            message: `Project with slug ${projectSlug} not found`,
          });
       } else {
          return res.json({

--- a/packages/server/src/routes/projectRoutes/__tests__/projectRoutes.test.ts
+++ b/packages/server/src/routes/projectRoutes/__tests__/projectRoutes.test.ts
@@ -1,13 +1,13 @@
-import request from "supertest";
 import express from "express";
+import request from "supertest";
 import projectRoutes from "../projectRoutes.js";
 
-// Mock the getProjectByName function
 vi.mock("../../../controllers/projectController/projectController.js", () => {
    return {
-      getProjectByName: vi.fn((req, res) => {
-         const projectName = req.params.projectName.toLowerCase();
-         if (projectName === "project one") {
+      getAllProjects: vi.fn((_req, res) => res.status(200).json([])),
+      getProjectBySlug: vi.fn((req, res) => {
+         const projectSlug = req.params.projectSlug.toLowerCase();
+         if (projectSlug === "project-one") {
             return res.status(200).json({ name: "Project One", description: "Description of Project One" });
          } else {
             return res.status(404).send("Project not found");
@@ -22,34 +22,34 @@ server.use("/projects", projectRoutes);
 
 describe("projectRoute route tests", () => {
    it("should respond with 200 status code for valid project", async () => {
-      const response = await request(server).get("/projects/Project One");
+      const response = await request(server).get("/projects/project-one");
       expect(response.status).toBe(200);
       expect(response.body.name).toBe("Project One");
    });
 
    it("should respond with 404 status code for invalid project", async () => {
-      const response = await request(server).get("/projects/Invalid Project");
+      const response = await request(server).get("/projects/invalid-project");
       expect(response.status).toBe(404);
    });
 
    it("should handle case insensitivity correctly", async () => {
-      const response = await request(server).get("/projects/pRoJect One");
+      const response = await request(server).get("/projects/pRoJect-one");
       expect(response.status).toBe(200);
       expect(response.body.name).toBe("Project One");
    });
 
-   it("should respond with 400 status code for empty project name", async () => {
+   it("should respond with 404 status code for empty project slug", async () => {
       const response = await request(server).get("/projects/");
       expect(response.status).toBe(404);
    });
 
    it("should handle special characters correctly", async () => {
-      const response = await request(server).get("/projects/Project@One!");
+      const response = await request(server).get("/projects/project@one!");
       expect(response.status).toBe(404);
    });
 
    it("should return correct response structure", async () => {
-      const response = await request(server).get("/projects/Project One");
+      const response = await request(server).get("/projects/project-one");
       expect(response.body).toHaveProperty("name");
       expect(response.body).toHaveProperty("description");
    });

--- a/packages/server/src/routes/projectRoutes/projectRoutes.ts
+++ b/packages/server/src/routes/projectRoutes/projectRoutes.ts
@@ -1,9 +1,9 @@
 import { Router } from "express";
-import { getAllProjects, getProjectByName } from "../../controllers/projectController/projectController.js";
+import { getAllProjects, getProjectBySlug } from "../../controllers/projectController/projectController.js";
 
 const projectRoutes = Router();
 
 projectRoutes.get("/", getAllProjects);
-projectRoutes.get("/:projectName", getProjectByName);
+projectRoutes.get("/:projectSlug", getProjectBySlug);
 
 export default projectRoutes;


### PR DESCRIPTION
## refactor: update project routing and API to use project_slug instead of project_name

---

## Description

PR title self-describes whatø's going on on this PR.

## How Has This Been Tested?

- [x] Manual testing
- [ ] Added new tests
- [ ] Existing tests passed
