### PR TITLE
fix: integrate useParams in useRelatedProjects for project-specific filtering

### DIFF
--- a/packages/client/src/features/project/components/project-related/components/project-related-container-compact/components/project-related-container-projects/__tests__/ProjectRelatedContainerProjects.test.tsx
+++ b/packages/client/src/features/project/components/project-related/components/project-related-container-compact/components/project-related-container-projects/__tests__/ProjectRelatedContainerProjects.test.tsx
@@ -5,6 +5,7 @@ import { mockProjects, resetModes, setupLightMode } from "./test-utils/testUtils
 vi.mock("react-router", () => ({
    ...vi.importActual("react-router"),
    Link: vi.fn(),
+   useParams: vi.fn().mockReturnValue({ projectSlug: "test-project" }),
 }));
 
 describe("ProjectRelatedContainerProjects tests", () => {

--- a/packages/client/src/features/project/components/project-related/components/project-related-container-compact/components/project-related-container-projects/utils/useRelatedProjects.tsx
+++ b/packages/client/src/features/project/components/project-related/components/project-related-container-compact/components/project-related-container-projects/utils/useRelatedProjects.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useParams } from "react-router";
 import useFetchData from "../../../../../../../../../utils/hooks/useFetchData/useFetchData";
 import type { ProjectInterface } from "../../../../../../../../../types/projectInterface";
 import { getRandomProjects } from "../data/projectRelatedContainerProjectsData";
@@ -10,17 +11,19 @@ export interface UseRelatedProjectsReturn {
 }
 
 export const useRelatedProjects = (): UseRelatedProjectsReturn => {
+   const { projectSlug } = useParams<{ projectSlug: string }>();
    const { data: allProjects, loading, error } = useFetchData<ProjectInterface[]>("/projects");
    const [relatedProjects, setRelatedProjects] = useState<ProjectInterface[]>([]);
 
    useEffect(() => {
       if (!loading && !error && allProjects && Array.isArray(allProjects) && allProjects.length > 0) {
-         const randomProjects = getRandomProjects(allProjects, 2);
+         const otherProjects = allProjects.filter((p) => p.project_slug !== projectSlug);
+         const randomProjects = getRandomProjects(otherProjects, 2);
          setRelatedProjects(randomProjects);
       } else if (!loading && !error && !allProjects) {
          setRelatedProjects([]);
       }
-   }, [allProjects, loading, error]);
+   }, [allProjects, loading, error, projectSlug]);
 
    return {
       relatedProjects,

--- a/packages/client/src/features/project/components/project-related/components/project-related-container-desktop/components/project-related-container-projects/__tests__/ProjectRelatedContainerProjects.test.tsx
+++ b/packages/client/src/features/project/components/project-related/components/project-related-container-desktop/components/project-related-container-projects/__tests__/ProjectRelatedContainerProjects.test.tsx
@@ -5,6 +5,7 @@ import { mockProjects, resetModes, setupLightMode } from "./test-utils/testUtils
 vi.mock("react-router", () => ({
    ...vi.importActual("react-router"),
    Link: vi.fn(),
+   useParams: vi.fn().mockReturnValue({ projectSlug: "test-project" }),
 }));
 
 describe("ProjectRelatedContainerProjects tests", () => {

--- a/packages/client/src/features/project/components/project-related/components/project-related-container-desktop/components/project-related-container-projects/utils/useRelatedProjects.tsx
+++ b/packages/client/src/features/project/components/project-related/components/project-related-container-desktop/components/project-related-container-projects/utils/useRelatedProjects.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { useParams } from "react-router";
 import useFetchData from "../../../../../../../../../utils/hooks/useFetchData/useFetchData";
 import type { ProjectInterface } from "../../../../../../../../../types/projectInterface";
 import { getRandomProjects } from "../data/projectRelatedContainerProjectsData";
@@ -10,17 +11,19 @@ export interface UseRelatedProjectsReturn {
 }
 
 export const useRelatedProjects = (): UseRelatedProjectsReturn => {
+   const { projectSlug } = useParams<{ projectSlug: string }>();
    const { data: allProjects, loading, error } = useFetchData<ProjectInterface[]>("/projects");
    const [relatedProjects, setRelatedProjects] = useState<ProjectInterface[]>([]);
 
    useEffect(() => {
       if (!loading && !error && allProjects && Array.isArray(allProjects) && allProjects.length > 0) {
-         const randomProjects = getRandomProjects(allProjects, 2);
+         const otherProjects = allProjects.filter((p) => p.project_slug !== projectSlug);
+         const randomProjects = getRandomProjects(otherProjects, 2);
          setRelatedProjects(randomProjects);
       } else if (!loading && !error && !allProjects) {
          setRelatedProjects([]);
       }
-   }, [allProjects, loading, error]);
+   }, [allProjects, loading, error, projectSlug]);
 
    return {
       relatedProjects,


### PR DESCRIPTION
## fix: integrate useParams in useRelatedProjects for project-specific filtering

---

## Description

PR title self-describes what's going on on this PR.

## How Has This Been Tested?

- [x] Manual testing
- [x] Added new tests
- [ ] Existing tests passed
